### PR TITLE
store CSV files for each agency and write their URLs to the db

### DIFF
--- a/.github/workflows/update_wrgl_urls.yml
+++ b/.github/workflows/update_wrgl_urls.yml
@@ -27,19 +27,24 @@ jobs:
 
       - name: Download and verify csv_urls.json
         run: |
+          # Get the folder name using the same pattern as the upload workflow
           FOLDER_NAME="data-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}"
+          
           echo "Checking for csv_urls.json in bucket..."
           if ! gsutil -q stat "gs://${{ vars.DATA_BUCKET }}/$FOLDER_NAME/csv_urls.json"; then
             echo "Error: csv_urls.json not found in cloud storage"
             exit 1
           fi
+          
           echo "Downloading csv_urls.json..."
           gsutil cp "gs://${{ vars.DATA_BUCKET }}/$FOLDER_NAME/csv_urls.json" ./csv_urls.json
+          
           echo "Verifying JSON format..."
           if ! jq empty csv_urls.json; then
             echo "Error: Invalid JSON format in csv_urls.json"
             exit 1
           fi
+          
           echo "Verifying JSON content..."
           URL_COUNT=$(jq 'length' csv_urls.json)
           echo "Found $URL_COUNT URL entries in csv_urls.json"
@@ -54,119 +59,9 @@ jobs:
           POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
           POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
         run: |
+          # Install Python and required packages
           sudo apt-get update && sudo apt-get install -y python3-pip
           pip install psycopg2-binary
-          cat << 'EOF' > update_wrgl.py
-          import psycopg2
-          import os
-          import json
-          import re
 
-          def get_slug_from_filename(filename):
-              match = re.match(r'[a-z]+_(.+)\.csv', filename)
-              if match:
-                  return match.group(1).replace('_', '-')
-              return None
-
-          def get_file_type(filename):
-              match = re.match(r'([a-z]+)_', filename)
-              if match:
-                  return match.group(1)
-              return None
-
-          def update_wrgl_urls():
-              success_count = 0
-              error_count = 0
-              skipped_count = 0
-              print("Starting database update process...")
-              try:
-                  conn = psycopg2.connect(
-                      dbname=os.environ['POSTGRES_DB'],
-                      user=os.environ['POSTGRES_USER'],
-                      password=os.environ['POSTGRES_PASSWORD'],
-                      host='localhost',
-                      port=5432
-                  )
-                  print("Successfully connected to database")
-                  try:
-                      with open('csv_urls.json', 'r') as f:
-                          urls = json.load(f)
-                      print(f"Loaded {len(urls)} URLs from csv_urls.json")
-                      with conn.cursor() as cur:
-                          all_slugs = set()
-                          cur.execute("SELECT slug FROM departments_wrglfile")
-                          for row in cur.fetchall():
-                              all_slugs.add(row[0])
-                          for filename, url in urls.items():
-                              print(f"\nProcessing {filename}...")
-                              slug = get_slug_from_filename(filename)
-                              file_type = get_file_type(filename)
-                              if not slug or not file_type:
-                                  print(f"ERROR: Could not determine slug or type from filename {filename}")
-                                  error_count += 1
-                                  continue
-                              if slug not in all_slugs:
-                                  print(f"WARNING: No matching record found for slug '{slug}'")
-                                  skipped_count += 1
-                                  continue
-                              try:
-                                  column_mapping = {
-                                      'per': ('url', 'download_url'),
-                                      'com': ('complaint_url', 'complaint_download_url'),
-                                      'uof': ('uof_url', 'uof_download_url'),
-                                      'sas': ('sas_url', 'sas_download_url'),
-                                      'app': ('appeals_url', 'appeals_download_url'),
-                                      'bra': ('brady_url', 'brady_download_url'),
-                                      'doc': ('documents_url', 'documents_download_url')
-                                  }
-                                  if file_type not in column_mapping:
-                                      print(f"WARNING: Unknown file type '{file_type}' for {filename}")
-                                      skipped_count += 1
-                                      continue
-                                  url_column, download_url_column = column_mapping[file_type]
-                                  cur.execute(f"""
-                                      UPDATE departments_wrglfile 
-                                      SET {url_column} = %s, {download_url_column} = %s 
-                                      WHERE slug = %s
-                                      RETURNING id
-                                  """, (url, url, slug))
-                                  updated = cur.fetchone()
-                                  if updated:
-                                      print(f"Successfully updated URLs for {slug}")
-                                      success_count += 1
-                                  else:
-                                      print(f"WARNING: No update performed for {slug}")
-                                      skipped_count += 1
-                              except Exception as e:
-                                  print(f"ERROR: Failed to update {slug}: {str(e)}")
-                                  error_count += 1
-                                  continue
-                          conn.commit()
-                          type_stats = {}
-                          for filename, url in urls.items():
-                              file_type = get_file_type(filename)
-                              if file_type:
-                                  type_stats[file_type] = type_stats.get(file_type, 0) + 1
-                          print("\nUpdate process completed:")
-                          print(f"- Successfully updated: {success_count}")
-                          print(f"- Skipped: {skipped_count}")
-                          print(f"- Errors: {error_count}")
-                          print("\nFiles processed by type:")
-                          for file_type, count in type_stats.items():
-                              print(f"- {file_type}: {count} files")
-                          if error_count > 0:
-                              raise Exception(f"Encountered {error_count} errors during update")
-                  except json.JSONDecodeError as e:
-                      raise Exception(f"Failed to parse csv_urls.json: {str(e)}")
-              except Exception as e:
-                  print(f"ERROR: {str(e)}")
-                  raise
-              finally:
-                  if 'conn' in locals():
-                      conn.close()
-                      print("Database connection closed")
-
-          if __name__ == '__main__':
-              update_wrgl_urls()
-          EOF
-          python3 update_wrgl.py
+          # Run the update script
+          python3 scripts/update_wrgl_urls.py

--- a/.github/workflows/update_wrgl_urls.yml
+++ b/.github/workflows/update_wrgl_urls.yml
@@ -25,11 +25,33 @@ jobs:
           instance: '${{ secrets.GCP_PROJECT_ID }}:us-central1:${{ secrets.CLOUD_SQL_DATABASE }}'
           port: 5432
 
-      - name: Download csv_urls.json
+      - name: Download and verify csv_urls.json
         run: |
           # Get the folder name using the same pattern as the upload workflow
           FOLDER_NAME="data-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}"
+          
+          echo "Checking for csv_urls.json in bucket..."
+          if ! gsutil -q stat "gs://${{ vars.DATA_BUCKET }}/$FOLDER_NAME/csv_urls.json"; then
+            echo "Error: csv_urls.json not found in cloud storage"
+            exit 1
+          fi
+          
+          echo "Downloading csv_urls.json..."
           gsutil cp "gs://${{ vars.DATA_BUCKET }}/$FOLDER_NAME/csv_urls.json" ./csv_urls.json
+          
+          echo "Verifying JSON format..."
+          if ! jq empty csv_urls.json; then
+            echo "Error: Invalid JSON format in csv_urls.json"
+            exit 1
+          fi
+          
+          echo "Verifying JSON content..."
+          URL_COUNT=$(jq 'length' csv_urls.json)
+          echo "Found $URL_COUNT URL entries in csv_urls.json"
+          if [ "$URL_COUNT" -eq "0" ]; then
+            echo "Error: No URLs found in csv_urls.json"
+            exit 1
+          fi
 
       - name: Update Database
         env:

--- a/.github/workflows/update_wrgl_urls.yml
+++ b/.github/workflows/update_wrgl_urls.yml
@@ -27,24 +27,19 @@ jobs:
 
       - name: Download and verify csv_urls.json
         run: |
-          # Get the folder name using the same pattern as the upload workflow
           FOLDER_NAME="data-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}"
-          
           echo "Checking for csv_urls.json in bucket..."
           if ! gsutil -q stat "gs://${{ vars.DATA_BUCKET }}/$FOLDER_NAME/csv_urls.json"; then
             echo "Error: csv_urls.json not found in cloud storage"
             exit 1
           fi
-          
           echo "Downloading csv_urls.json..."
           gsutil cp "gs://${{ vars.DATA_BUCKET }}/$FOLDER_NAME/csv_urls.json" ./csv_urls.json
-          
           echo "Verifying JSON format..."
           if ! jq empty csv_urls.json; then
             echo "Error: Invalid JSON format in csv_urls.json"
             exit 1
           fi
-          
           echo "Verifying JSON content..."
           URL_COUNT=$(jq 'length' csv_urls.json)
           echo "Found $URL_COUNT URL entries in csv_urls.json"
@@ -59,64 +54,119 @@ jobs:
           POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
           POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
         run: |
-          # Install Python and required packages
           sudo apt-get update && sudo apt-get install -y python3-pip
           pip install psycopg2-binary
-
-          # Create Python script to update database
-          cat << EOF > update_wrgl.py
+          cat << 'EOF' > update_wrgl.py
           import psycopg2
           import os
           import json
           import re
 
           def get_slug_from_filename(filename):
-              # Extract agency name from filename like 'per_new_orleans_pd.csv'
-              match = re.match(r'per_(.+)\.csv', filename)
+              match = re.match(r'[a-z]+_(.+)\.csv', filename)
               if match:
                   return match.group(1).replace('_', '-')
               return None
 
+          def get_file_type(filename):
+              match = re.match(r'([a-z]+)_', filename)
+              if match:
+                  return match.group(1)
+              return None
+
           def update_wrgl_urls():
-              conn = psycopg2.connect(
-                  dbname=os.environ['POSTGRES_DB'],
-                  user=os.environ['POSTGRES_USER'],
-                  password=os.environ['POSTGRES_PASSWORD'],
-                  host='localhost',
-                  port=5432
-              )
-              
+              success_count = 0
+              error_count = 0
+              skipped_count = 0
+              print("Starting database update process...")
               try:
-                  with open('csv_urls.json', 'r') as f:
-                      urls = json.load(f)
-                  
-                  with conn.cursor() as cur:
-                      for filename, url in urls.items():
-                          slug = get_slug_from_filename(filename)
-                          if not slug:
-                              print(f"Skipping {filename} - could not determine slug")
-                              continue
-                              
-                          cur.execute("""
-                              UPDATE departments_wrglfile 
-                              SET url = %s, download_url = %s 
-                              WHERE slug = %s
-                              RETURNING id
-                          """, (url, url, slug))
-                          
-                          updated = cur.fetchone()
-                          if updated:
-                              print(f"Updated URLs for {slug}")
-                          else:
-                              print(f"No matching record found for {slug}")
-                      
-                      conn.commit()
+                  conn = psycopg2.connect(
+                      dbname=os.environ['POSTGRES_DB'],
+                      user=os.environ['POSTGRES_USER'],
+                      password=os.environ['POSTGRES_PASSWORD'],
+                      host='localhost',
+                      port=5432
+                  )
+                  print("Successfully connected to database")
+                  try:
+                      with open('csv_urls.json', 'r') as f:
+                          urls = json.load(f)
+                      print(f"Loaded {len(urls)} URLs from csv_urls.json")
+                      with conn.cursor() as cur:
+                          all_slugs = set()
+                          cur.execute("SELECT slug FROM departments_wrglfile")
+                          for row in cur.fetchall():
+                              all_slugs.add(row[0])
+                          for filename, url in urls.items():
+                              print(f"\nProcessing {filename}...")
+                              slug = get_slug_from_filename(filename)
+                              file_type = get_file_type(filename)
+                              if not slug or not file_type:
+                                  print(f"ERROR: Could not determine slug or type from filename {filename}")
+                                  error_count += 1
+                                  continue
+                              if slug not in all_slugs:
+                                  print(f"WARNING: No matching record found for slug '{slug}'")
+                                  skipped_count += 1
+                                  continue
+                              try:
+                                  column_mapping = {
+                                      'per': ('url', 'download_url'),
+                                      'com': ('complaint_url', 'complaint_download_url'),
+                                      'uof': ('uof_url', 'uof_download_url'),
+                                      'sas': ('sas_url', 'sas_download_url'),
+                                      'app': ('appeals_url', 'appeals_download_url'),
+                                      'bra': ('brady_url', 'brady_download_url'),
+                                      'doc': ('documents_url', 'documents_download_url')
+                                  }
+                                  if file_type not in column_mapping:
+                                      print(f"WARNING: Unknown file type '{file_type}' for {filename}")
+                                      skipped_count += 1
+                                      continue
+                                  url_column, download_url_column = column_mapping[file_type]
+                                  cur.execute(f"""
+                                      UPDATE departments_wrglfile 
+                                      SET {url_column} = %s, {download_url_column} = %s 
+                                      WHERE slug = %s
+                                      RETURNING id
+                                  """, (url, url, slug))
+                                  updated = cur.fetchone()
+                                  if updated:
+                                      print(f"Successfully updated URLs for {slug}")
+                                      success_count += 1
+                                  else:
+                                      print(f"WARNING: No update performed for {slug}")
+                                      skipped_count += 1
+                              except Exception as e:
+                                  print(f"ERROR: Failed to update {slug}: {str(e)}")
+                                  error_count += 1
+                                  continue
+                          conn.commit()
+                          type_stats = {}
+                          for filename, url in urls.items():
+                              file_type = get_file_type(filename)
+                              if file_type:
+                                  type_stats[file_type] = type_stats.get(file_type, 0) + 1
+                          print("\nUpdate process completed:")
+                          print(f"- Successfully updated: {success_count}")
+                          print(f"- Skipped: {skipped_count}")
+                          print(f"- Errors: {error_count}")
+                          print("\nFiles processed by type:")
+                          for file_type, count in type_stats.items():
+                              print(f"- {file_type}: {count} files")
+                          if error_count > 0:
+                              raise Exception(f"Encountered {error_count} errors during update")
+                  except json.JSONDecodeError as e:
+                      raise Exception(f"Failed to parse csv_urls.json: {str(e)}")
+              except Exception as e:
+                  print(f"ERROR: {str(e)}")
+                  raise
               finally:
-                  conn.close()
+                  if 'conn' in locals():
+                      conn.close()
+                      print("Database connection closed")
 
           if __name__ == '__main__':
               update_wrgl_urls()
           EOF
-
-          # Run the update script
           python3 update_wrgl.py

--- a/.github/workflows/update_wrgl_urls.yml
+++ b/.github/workflows/update_wrgl_urls.yml
@@ -1,0 +1,100 @@
+name: Update WRGL URLs
+
+on:
+  workflow_run:
+    workflows: ["Upload CSV to Google Cloud"]
+    types:
+      - completed
+
+jobs:
+  update-urls:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      
+      # Set up Cloud SQL Auth proxy
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.GCP_SA_KEY }}'
+          
+      - name: 'Set up Cloud SQL Proxy'
+        uses: 'google-github-actions/setup-cloud-sql-proxy@v1'
+        with:
+          instance: '${{ secrets.GCP_PROJECT_ID }}:us-central1:${{ secrets.CLOUD_SQL_DATABASE }}'
+          port: 5432
+
+      - name: Download csv_urls.json
+        run: |
+          # Get the folder name using the same pattern as the upload workflow
+          FOLDER_NAME="data-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}"
+          gsutil cp "gs://${{ vars.DATA_BUCKET }}/$FOLDER_NAME/csv_urls.json" ./csv_urls.json
+
+      - name: Update Database
+        env:
+          POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
+          POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+        run: |
+          # Install Python and required packages
+          sudo apt-get update && sudo apt-get install -y python3-pip
+          pip install psycopg2-binary
+
+          # Create Python script to update database
+          cat << EOF > update_wrgl.py
+          import psycopg2
+          import os
+          import json
+          import re
+
+          def get_slug_from_filename(filename):
+              # Extract agency name from filename like 'per_new_orleans_pd.csv'
+              match = re.match(r'per_(.+)\.csv', filename)
+              if match:
+                  return match.group(1).replace('_', '-')
+              return None
+
+          def update_wrgl_urls():
+              conn = psycopg2.connect(
+                  dbname=os.environ['POSTGRES_DB'],
+                  user=os.environ['POSTGRES_USER'],
+                  password=os.environ['POSTGRES_PASSWORD'],
+                  host='localhost',
+                  port=5432
+              )
+              
+              try:
+                  with open('csv_urls.json', 'r') as f:
+                      urls = json.load(f)
+                  
+                  with conn.cursor() as cur:
+                      for filename, url in urls.items():
+                          slug = get_slug_from_filename(filename)
+                          if not slug:
+                              print(f"Skipping {filename} - could not determine slug")
+                              continue
+                              
+                          cur.execute("""
+                              UPDATE departments_wrglfile 
+                              SET url = %s, download_url = %s 
+                              WHERE slug = %s
+                              RETURNING id
+                          """, (url, url, slug))
+                          
+                          updated = cur.fetchone()
+                          if updated:
+                              print(f"Updated URLs for {slug}")
+                          else:
+                              print(f"No matching record found for {slug}")
+                      
+                      conn.commit()
+              finally:
+                  conn.close()
+
+          if __name__ == '__main__':
+              update_wrgl_urls()
+          EOF
+
+          # Run the update script
+          python3 update_wrgl.py

--- a/.github/workflows/upload_csv_to_google_cloud.yml
+++ b/.github/workflows/upload_csv_to_google_cloud.yml
@@ -109,6 +109,7 @@ jobs:
         destination: '${{ vars.DATA_BUCKET }}/${{ env.FOLDER_NAME }}/fuse_agency'
         process_gcloudignore: false
         recursive: true
+
     # Verify files exist before processing
     - name: 'Verify CSV files'
       run: |
@@ -118,9 +119,10 @@ jobs:
           exit 1
         fi
         
-        # List all personnel CSVs to verify they exist
-        echo "Found personnel CSV files:"
-        find /runner/_work/data/data/fuse_agency -name "per_*.csv" -type f -ls
+        # List all agency CSVs to verify they exist
+        echo "Found agency CSV files:"
+        find /runner/_work/data/data/fuse_agency -name "*.csv" -type f -ls
+
     - name: 'Generate CSV URLs file'
       run: |
         echo "Generating URLs for uploaded files..."
@@ -128,9 +130,9 @@ jobs:
         
         # Verify files were uploaded successfully
         echo "Verifying uploaded files in Google Cloud Storage..."
-        UPLOADED_FILES=$(gsutil ls "gs://${{ vars.DATA_BUCKET }}/${{ env.FOLDER_NAME }}/fuse_agency/per_*.csv")
+        UPLOADED_FILES=$(gsutil ls "gs://${{ vars.DATA_BUCKET }}/${{ env.FOLDER_NAME }}/fuse_agency/*.csv")
         if [ -z "$UPLOADED_FILES" ]; then
-          echo "Error: No personnel CSV files found in cloud storage"
+          echo "Error: No agency CSV files found in cloud storage"
           exit 1
         fi
         
@@ -142,7 +144,8 @@ jobs:
         echo "$UPLOADED_FILES" | while read -r file; do
           if [ ! -z "$file" ]; then
             filename=$(basename "$file")
-            echo "Processing $filename..."
+            filetype=${filename%%_*}  # Extract type (per, com, uof, etc.)
+            echo "Processing $filename (type: $filetype)..."
             echo "  \"${filename}\": \"https://storage.googleapis.com/${file#gs://}\"," >> csv_urls.json
           fi
         done
@@ -150,7 +153,7 @@ jobs:
         # Remove trailing comma and close JSON
         sed -i '$ s/,$//' csv_urls.json
         echo "}" >> csv_urls.json
-
+        
         # Verify JSON format
         echo "Verifying JSON format..."
         if ! jq empty csv_urls.json; then
@@ -162,12 +165,12 @@ jobs:
         # Upload the URLs file back to cloud storage
         gsutil cp csv_urls.json "gs://${{ vars.DATA_BUCKET }}/${{ env.FOLDER_NAME }}/csv_urls.json"
         
-        # Make the CSV files and URLs file publicly readable
-        gsutil -m acl ch -r -u AllUsers:R "gs://${{ vars.DATA_BUCKET }}/${{ env.FOLDER_NAME }}/fuse_agency/per_*.csv"
+        # Make all CSV files and URLs file publicly readable
+        gsutil -m acl ch -r -u AllUsers:R "gs://${{ vars.DATA_BUCKET }}/${{ env.FOLDER_NAME }}/fuse_agency/*.csv"
         gsutil acl ch -u AllUsers:R "gs://${{ vars.DATA_BUCKET }}/${{ env.FOLDER_NAME }}/csv_urls.json"
         
         echo "URL generation and permission setting completed successfully"
-        - name: 'Trigger Backend staging data import'
+    - name: 'Trigger Backend staging data import'
       id: 'trigger-backend-staging'
       run: |
         curl -X POST -H "Content-Type: application/json" \

--- a/.github/workflows/upload_csv_to_google_cloud.yml
+++ b/.github/workflows/upload_csv_to_google_cloud.yml
@@ -105,34 +105,69 @@ jobs:
     - id: 'upload-agency-csvs'
       uses: 'google-github-actions/upload-cloud-storage@v2'
       with:
-        path: '${{ vars.DATA_DIR }}/fuse_agency'
+        path: '/runner/_work/data/data/fuse_agency'
         destination: '${{ vars.DATA_BUCKET }}/${{ env.FOLDER_NAME }}/fuse_agency'
         process_gcloudignore: false
         recursive: true
-
+    # Verify files exist before processing
+    - name: 'Verify CSV files'
+      run: |
+        echo "Verifying CSV files exist..."
+        if [ ! -d "/runner/_work/data/data/fuse_agency" ]; then
+          echo "Error: fuse_agency directory not found"
+          exit 1
+        fi
+        
+        # List all personnel CSVs to verify they exist
+        echo "Found personnel CSV files:"
+        find /runner/_work/data/data/fuse_agency -name "per_*.csv" -type f -ls
     - name: 'Generate CSV URLs file'
       run: |
         echo "Generating URLs for uploaded files..."
         echo "{" > csv_urls.json
         
-        # List all uploaded CSVs and generate their public URLs
-        # Focus on agency-specific CSVs from fuse_agency directory
-        gsutil ls "gs://${{ vars.DATA_BUCKET }}/${{ env.FOLDER_NAME }}/fuse_agency/per_*.csv" | while read -r file; do
-          filename=$(basename "$file")
-          echo "  \"${filename}\": \"https://storage.googleapis.com/${file#gs://}\"," >> csv_urls.json
+        # Verify files were uploaded successfully
+        echo "Verifying uploaded files in Google Cloud Storage..."
+        UPLOADED_FILES=$(gsutil ls "gs://${{ vars.DATA_BUCKET }}/${{ env.FOLDER_NAME }}/fuse_agency/per_*.csv")
+        if [ -z "$UPLOADED_FILES" ]; then
+          echo "Error: No personnel CSV files found in cloud storage"
+          exit 1
+        fi
+        
+        echo "Found the following uploaded files:"
+        echo "$UPLOADED_FILES"
+        
+        # Generate URLs for verified files
+        echo "Generating public URLs..."
+        echo "$UPLOADED_FILES" | while read -r file; do
+          if [ ! -z "$file" ]; then
+            filename=$(basename "$file")
+            echo "Processing $filename..."
+            echo "  \"${filename}\": \"https://storage.googleapis.com/${file#gs://}\"," >> csv_urls.json
+          fi
         done
         
         # Remove trailing comma and close JSON
         sed -i '$ s/,$//' csv_urls.json
         echo "}" >> csv_urls.json
+
+        # Verify JSON format
+        echo "Verifying JSON format..."
+        if ! jq empty csv_urls.json; then
+          echo "Error: Invalid JSON format"
+          exit 1
+        fi
         
+        echo "Uploading URLs file and setting permissions..."
         # Upload the URLs file back to cloud storage
         gsutil cp csv_urls.json "gs://${{ vars.DATA_BUCKET }}/${{ env.FOLDER_NAME }}/csv_urls.json"
         
         # Make the CSV files and URLs file publicly readable
         gsutil -m acl ch -r -u AllUsers:R "gs://${{ vars.DATA_BUCKET }}/${{ env.FOLDER_NAME }}/fuse_agency/per_*.csv"
         gsutil acl ch -u AllUsers:R "gs://${{ vars.DATA_BUCKET }}/${{ env.FOLDER_NAME }}/csv_urls.json"
-    - name: 'Trigger Backend staging data import'
+        
+        echo "URL generation and permission setting completed successfully"
+        - name: 'Trigger Backend staging data import'
       id: 'trigger-backend-staging'
       run: |
         curl -X POST -H "Content-Type: application/json" \

--- a/.github/workflows/upload_csv_to_google_cloud.yml
+++ b/.github/workflows/upload_csv_to_google_cloud.yml
@@ -101,6 +101,37 @@ jobs:
         destination: '${{ vars.DATA_BUCKET }}/${{ env.FOLDER_NAME }}'
         process_gcloudignore: false
 
+    # Upload agency-specific input CSVs and save URLs
+    - id: 'upload-agency-csvs'
+      uses: 'google-github-actions/upload-cloud-storage@v2'
+      with:
+        path: '${{ vars.DATA_DIR }}/fuse_agency'
+        destination: '${{ vars.DATA_BUCKET }}/${{ env.FOLDER_NAME }}/fuse_agency'
+        process_gcloudignore: false
+        recursive: true
+
+    - name: 'Generate CSV URLs file'
+      run: |
+        echo "Generating URLs for uploaded files..."
+        echo "{" > csv_urls.json
+        
+        # List all uploaded CSVs and generate their public URLs
+        # Focus on agency-specific CSVs from fuse_agency directory
+        gsutil ls "gs://${{ vars.DATA_BUCKET }}/${{ env.FOLDER_NAME }}/fuse_agency/per_*.csv" | while read -r file; do
+          filename=$(basename "$file")
+          echo "  \"${filename}\": \"https://storage.googleapis.com/${file#gs://}\"," >> csv_urls.json
+        done
+        
+        # Remove trailing comma and close JSON
+        sed -i '$ s/,$//' csv_urls.json
+        echo "}" >> csv_urls.json
+        
+        # Upload the URLs file back to cloud storage
+        gsutil cp csv_urls.json "gs://${{ vars.DATA_BUCKET }}/${{ env.FOLDER_NAME }}/csv_urls.json"
+        
+        # Make the CSV files and URLs file publicly readable
+        gsutil -m acl ch -r -u AllUsers:R "gs://${{ vars.DATA_BUCKET }}/${{ env.FOLDER_NAME }}/fuse_agency/per_*.csv"
+        gsutil acl ch -u AllUsers:R "gs://${{ vars.DATA_BUCKET }}/${{ env.FOLDER_NAME }}/csv_urls.json"
     - name: 'Trigger Backend staging data import'
       id: 'trigger-backend-staging'
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ db.txt
 
 dvc-env/
 *.json
+*.patch

--- a/scripts/update_wrgl_urls.py
+++ b/scripts/update_wrgl_urls.py
@@ -134,7 +134,7 @@ def update_wrgl_urls(json_path='csv_urls.json'):
             
     except Exception as e:
         logger.error(f"ERROR: {str(e)}")
-        raise
+        raise e
         
     finally:
         if 'conn' in locals():

--- a/scripts/update_wrgl_urls.py
+++ b/scripts/update_wrgl_urls.py
@@ -1,0 +1,145 @@
+import psycopg2
+import os
+import json
+import re
+import logging
+
+# Set up logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+def get_slug_from_filename(filename):
+    # Extract agency name from filenames like:
+    # per_new_orleans_pd.csv
+    # com_new_orleans_pd.csv
+    # uof_new_orleans_pd.csv
+    # etc.
+    match = re.match(r'[a-z]+_(.+)\.csv', filename)
+    if match:
+        return match.group(1).replace('_', '-')
+    return None
+
+def get_file_type(filename):
+    # Extract type from filename (per, com, uof, etc.)
+    match = re.match(r'([a-z]+)_', filename)
+    if match:
+        return match.group(1)
+    return None
+
+def update_wrgl_urls(json_path='csv_urls.json'):
+    success_count = 0
+    error_count = 0
+    skipped_count = 0
+    type_stats = {}
+    
+    logger.info("Starting database update process...")
+    
+    try:
+        conn = psycopg2.connect(
+            dbname=os.environ['POSTGRES_DB'],
+            user=os.environ['POSTGRES_USER'],
+            password=os.environ['POSTGRES_PASSWORD'],
+            host='localhost',
+            port=5432
+        )
+        logger.info("Successfully connected to database")
+        
+        try:
+            with open(json_path, 'r') as f:
+                urls = json.load(f)
+            logger.info(f"Loaded {len(urls)} URLs from {json_path}")
+            
+            with conn.cursor() as cur:
+                # First, verify all slugs exist
+                all_slugs = set()
+                cur.execute("SELECT slug FROM departments_wrglfile")
+                for row in cur.fetchall():
+                    all_slugs.add(row[0])
+                
+                # Map file type to column names
+                column_mapping = {
+                    'per': ('url', 'download_url'),  # personnel files
+                    'com': ('complaint_url', 'complaint_download_url'),  # complaints
+                    'uof': ('uof_url', 'uof_download_url'),  # use of force
+                    'sas': ('sas_url', 'sas_download_url'),  # stop and search
+                    'app': ('appeals_url', 'appeals_download_url'),  # appeals
+                    'bra': ('brady_url', 'brady_download_url'),  # brady
+                    'doc': ('documents_url', 'documents_download_url')  # documents
+                }
+                
+                for filename, url in urls.items():
+                    logger.info(f"\nProcessing {filename}...")
+                    slug = get_slug_from_filename(filename)
+                    file_type = get_file_type(filename)
+                    
+                    # Update type statistics
+                    if file_type:
+                        type_stats[file_type] = type_stats.get(file_type, 0) + 1
+                    
+                    if not slug or not file_type:
+                        logger.error(f"Could not determine slug or type from filename {filename}")
+                        error_count += 1
+                        continue
+                    
+                    if slug not in all_slugs:
+                        logger.warning(f"No matching record found for slug '{slug}'")
+                        skipped_count += 1
+                        continue
+                    
+                    if file_type not in column_mapping:
+                        logger.warning(f"Unknown file type '{file_type}' for {filename}")
+                        skipped_count += 1
+                        continue
+                    
+                    try:
+                        url_column, download_url_column = column_mapping[file_type]
+                        
+                        cur.execute(f"""
+                            UPDATE departments_wrglfile 
+                            SET {url_column} = %s, {download_url_column} = %s 
+                            WHERE slug = %s
+                            RETURNING id
+                        """, (url, url, slug))
+                        
+                        updated = cur.fetchone()
+                        if updated:
+                            logger.info(f"Successfully updated URLs for {slug}")
+                            success_count += 1
+                        else:
+                            logger.warning(f"No update performed for {slug}")
+                            skipped_count += 1
+                            
+                    except Exception as e:
+                        logger.error(f"Failed to update {slug}: {str(e)}")
+                        error_count += 1
+                        continue
+                
+                conn.commit()
+                logger.info("\nUpdate process completed:")
+                logger.info(f"- Successfully updated: {success_count}")
+                logger.info(f"- Skipped: {skipped_count}")
+                logger.info(f"- Errors: {error_count}")
+                logger.info("\nFiles processed by type:")
+                for file_type, count in type_stats.items():
+                    logger.info(f"- {file_type}: {count} files")
+                
+                if error_count > 0:
+                    raise Exception(f"Encountered {error_count} errors during update")
+                    
+        except json.JSONDecodeError as e:
+            raise Exception(f"Failed to parse {json_path}: {str(e)}")
+            
+    except Exception as e:
+        logger.error(f"ERROR: {str(e)}")
+        raise
+        
+    finally:
+        if 'conn' in locals():
+            conn.close()
+            logger.info("Database connection closed")
+
+if __name__ == '__main__':
+    update_wrgl_urls()


### PR DESCRIPTION
This commit introduces two key workflow changes to handle agency-specific CSV files:

1. Enhanced upload_csv_to_google_cloud.yml:
   - Added support for uploading agency-specific CSVs from fuse_agency directory
   - Generates a JSON file (csv_urls.json) mapping filenames to their public URLs
   - Sets appropriate public access permissions for uploaded files

2. Added new workflow update_wrgl_urls.yml:
   - Automatically triggers after successful CSV upload
   - Securely connects to Cloud SQL using Cloud SQL Proxy
   - Downloads the generated csv_urls.json file
   - Updates departments_wrglfile table in PostgreSQL database
   - Maps CSV filenames to agency slugs (e.g., per_new_orleans_pd.csv → new-orleans-pd)
   - Updates both url and download_url fields for each agency

Required Secrets:
- GCP_SA_KEY: Google Cloud service account credentials
- GCP_PROJECT_ID: Google Cloud project identifier
- CLOUD_SQL_DATABASE: Cloud SQL instance name
- POSTGRES_DB, POSTGRES_USER, POSTGRES_PASSWORD: Database credentials

This change ensures that agency-specific CSV files are automatically uploaded to Google Cloud Storage and their URLs are properly updated in the [LLEAD Django](https://github.com/publicdataworks/llead-backend) application's database, maintaining synchronization between data processing and the frontend application.